### PR TITLE
Implement Hash for models

### DIFF
--- a/em-client/Cargo.lock
+++ b/em-client/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "em-client"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "base64 0.10.1",
  "bitflags",

--- a/em-client/Cargo.lock
+++ b/em-client/Cargo.lock
@@ -401,9 +401,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "mbedtls"
-version = "0.9.3"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a846b1d4b990bc3d900554a12528dfe4b3ab920eac016ee5b314aef4f8e4a9"
+checksum = "8730cf71e8d79ba70b3b7986af7af7629c0c4ee58b59e4a2e30d855cc31552e8"
 dependencies = [
  "bitflags 1.2.1",
  "byteorder",

--- a/em-client/Cargo.lock
+++ b/em-client/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "em-client"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "base64 0.10.1",
  "bitflags 1.2.1",

--- a/em-client/Cargo.lock
+++ b/em-client/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "em-client"
-version = "3.1.0"
+version = "3.0.0"
 dependencies = [
  "base64 0.10.1",
  "bitflags 1.2.1",

--- a/em-client/Cargo.lock
+++ b/em-client/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "em-client"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "base64 0.10.1",
  "bitflags 1.2.1",

--- a/em-client/Cargo.lock
+++ b/em-client/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "em-client"
-version = "4.0.0"
+version = "3.0.0"
 dependencies = [
  "base64 0.10.1",
  "bitflags 1.2.1",

--- a/em-client/Cargo.lock
+++ b/em-client/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,7 +53,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0df2f85c8a2abbe3b7d7e748052fdd9b76a0458fdeb16ad4223f5eca78c7c130"
 dependencies = [
  "addr2line",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "object",
  "rustc-demangle",
@@ -70,10 +79,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.65.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+dependencies = [
+ "bitflags 1.2.1",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log 0.4.8",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.76",
+ "which",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "byteorder"
@@ -82,10 +126,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
+name = "cc"
+version = "1.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
@@ -100,6 +168,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,7 +186,7 @@ checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.2.1",
  "strsim",
  "textwrap",
  "unicode-width",
@@ -115,11 +194,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
 name = "em-client"
 version = "4.0.0"
 dependencies = [
  "base64 0.10.1",
- "bitflags",
+ "bitflags 1.2.1",
  "chrono",
  "clap",
  "error-chain",
@@ -127,6 +221,7 @@ dependencies = [
  "hyper",
  "lazy_static",
  "log 0.3.9",
+ "mbedtls",
  "mime",
  "serde",
  "serde_derive",
@@ -134,6 +229,16 @@ dependencies = [
  "serde_json",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -165,12 +270,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -228,10 +348,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "libc"
-version = "0.2.71"
+name = "lazycell"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "libc"
+version = "0.2.158"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+
+[[package]]
+name = "libloading"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "log"
@@ -248,7 +390,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -258,12 +400,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "mbedtls"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a846b1d4b990bc3d900554a12528dfe4b3ab920eac016ee5b314aef4f8e4a9"
+dependencies = [
+ "bitflags 1.2.1",
+ "byteorder",
+ "cc",
+ "cfg-if 1.0.0",
+ "mbedtls-platform-support",
+ "mbedtls-sys-auto",
+ "rs-libc",
+ "serde",
+ "serde_derive",
+ "yasna",
+]
+
+[[package]]
+name = "mbedtls-platform-support"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be354d52c70402fbfb37bad9ae2aa99ab52af79f37423cb9d6c41c8fb863abc7"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "chrono",
+ "mbedtls-sys-auto",
+]
+
+[[package]]
+name = "mbedtls-sys-auto"
+version = "2.28.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11bb8ccdfd2a163117d977677665a2008fbd9ab38c884b0b8a57828219868dc0"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cfg-if 1.0.0",
+ "cmake",
+ "lazy_static",
+ "libc",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "mime"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 dependencies = [
  "log 0.3.9",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -302,25 +523,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
 
 [[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.18"
+name = "prettyplease"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
+checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
- "unicode-xid",
+ "proc-macro2",
+ "syn 2.0.76",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.6"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -363,10 +606,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
+name = "rs-libc"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683e8c8e8aac6ffa4b2287bac3c69575d5346accac4f218ae1e084303bb174ca"
+dependencies = [
+ "cc",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.38.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "ryu"
@@ -394,7 +695,7 @@ checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -418,6 +719,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "smallvec"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,13 +738,24 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.30"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -490,6 +808,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,12 +827,6 @@ name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "url"
@@ -527,7 +845,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "rand",
  "serde",
 ]
@@ -551,6 +869,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,3 +901,92 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "yasna"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79af3189e6b0484c9fd54208f8eeb8818cadee00ec81438b67a64c8e6f2f3694"
+dependencies = [
+ "bit-vec",
+ "num-bigint",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/em-client/Cargo.toml
+++ b/em-client/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "em-client"
-version = "3.1.0"
+version = "4.0.0"
 authors = ["Fortanix Inc."]
 license = "MPL-2.0"
 description = "This crate provides rust bindings for Enclave Manager API."

--- a/em-client/Cargo.toml
+++ b/em-client/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "em-client"
-version = "4.0.0"
+version = "3.0.0"
 authors = ["Fortanix Inc."]
 license = "MPL-2.0"
 description = "This crate provides rust bindings for Enclave Manager API."

--- a/em-client/Cargo.toml
+++ b/em-client/Cargo.toml
@@ -27,6 +27,7 @@ uuid = {version = "0.6", features = ["serde", "v4"]}
 hyper = {version = "0.10", default-features = false, optional = true}
 serde_ignored = {version = "0.0.4", optional = true}
 url = {version = "1.5", optional = true}
+mbedtls = { version = "0.9" }
 
 [dev-dependencies]
 clap = "2.25"

--- a/em-client/Cargo.toml
+++ b/em-client/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "em-client"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["Fortanix Inc."]
 license = "MPL-2.0"
 description = "This crate provides rust bindings for Enclave Manager API."

--- a/em-client/Cargo.toml
+++ b/em-client/Cargo.toml
@@ -27,7 +27,7 @@ uuid = {version = "0.6", features = ["serde", "v4"]}
 hyper = {version = "0.10", default-features = false, optional = true}
 serde_ignored = {version = "0.0.4", optional = true}
 url = {version = "1.5", optional = true}
-mbedtls = { version = "0.9" }
+mbedtls = { version = "0.12" }
 
 [dev-dependencies]
 clap = "2.25"

--- a/em-client/Cargo.toml
+++ b/em-client/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "em-client"
-version = "3.0.0"
+version = "4.0.0"
 authors = ["Fortanix Inc."]
 license = "MPL-2.0"
 description = "This crate provides rust bindings for Enclave Manager API."

--- a/em-client/src/client/mod.rs
+++ b/em-client/src/client/mod.rs
@@ -184,62 +184,6 @@ impl Client {
     pub fn headers(&mut self) -> &mut Headers {
         &mut self.headers
     }
-
-    fn get_runtime_application_config_raw(&self) -> Result<String, ApiError> {
-        let mut url = format!(
-            "{}/v1/runtime/app_configs",
-            self.base_path
-        );
-
-        let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
-
-        let query_string_str = query_string.finish();
-        if !query_string_str.is_empty() {
-            url += "?";
-            url += &query_string_str;
-        }
-
-        let url = match Url::from_str(&url) {
-            Ok(url) => url,
-            Err(err) => return Err(ApiError::new(format!("Unable to build URL: {}", err), SimpleErrorType::Permanent)),
-        };
-
-        let mut request = self.hyper_client.request(Method::Get, url);
-        request = request.headers(self.headers.clone());
-
-        request.send()
-            .map_err(|e| ApiError::new(format!("No response received: {}", e), SimpleErrorType::Permanent))
-            .and_then(|mut response| {
-                match response.status.to_u16() {
-                    200 => {
-                        let mut body = Vec::new();
-                        response.read_to_end(&mut body)
-                            .map_err(|e| ApiError::new(format!("Failed to read response: {}", e), SimpleErrorType::Temporary))?;
-                        String::from_utf8(body)
-                            .map_err(|e| ApiError::new(format!("Response was not valid UTF8: {}", e), SimpleErrorType::Temporary))
-                    },
-                    code => {
-                        let headers = response.headers.clone();
-                        let mut body = Vec::new();
-                        let result = response.read_to_end(&mut body);
-                        let err_type = match response.status.is_server_error() {
-                            false => SimpleErrorType::Permanent,
-                            true => SimpleErrorType::Temporary,
-                        };
-                        Err(ApiError::new(format!("Unexpected response code {}:\n{:?}\n\n{}",
-                                                  code,
-                                                  headers,
-                                                  match result {
-                                                      Ok(_) => match str::from_utf8(&body) {
-                                                          Ok(body) => Cow::from(body),
-                                                          Err(e) => Cow::from(format!("<Body was not UTF8: {:?}>", e)),
-                                                      },
-                                                      Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
-                                                  }), err_type))
-                    }
-                }
-            })
-    }
 }
 
 
@@ -1405,27 +1349,72 @@ impl ApplicationConfigApi for Client {
 
     }
 
-    fn get_checked_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error> {
-        let raw_config = self.get_runtime_application_config_raw()?;
+    fn get_runtime_application_config(&self, expected_hash: &[u8; 32]) -> Result<models::RuntimeAppConfig, ApiError> {
+        let mut url = format!(
+            "{}/v1/runtime/app_configs",
+            self.base_path
+        );
+
+        let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
+
+        let query_string_str = query_string.finish();
+        if !query_string_str.is_empty() {
+            url += "?";
+            url += &query_string_str;
+        }
+
+        let url = match Url::from_str(&url) {
+            Ok(url) => url,
+            Err(err) => return Err(ApiError::new(format!("Unable to build URL: {}", err), SimpleErrorType::Permanent)),
+        };
+
+        let mut request = self.hyper_client.request(Method::Get, url);
+        request = request.headers(self.headers.clone());
+
+        let raw_config = request.send()
+            .map_err(|e| ApiError::new(format!("No response received: {}", e), SimpleErrorType::Permanent))
+            .and_then(|mut response| {
+                match response.status.to_u16() {
+                    200 => {
+                        let mut body = Vec::new();
+                        response.read_to_end(&mut body)
+                            .map_err(|e| ApiError::new(format!("Failed to read response: {}", e), SimpleErrorType::Temporary))?;
+                        String::from_utf8(body)
+                            .map_err(|e| ApiError::new(format!("Response was not valid UTF8: {}", e), SimpleErrorType::Temporary))
+                    },
+                    code => {
+                        let headers = response.headers.clone();
+                        let mut body = Vec::new();
+                        let result = response.read_to_end(&mut body);
+                        let err_type = match response.status.is_server_error() {
+                            false => SimpleErrorType::Permanent,
+                            true => SimpleErrorType::Temporary,
+                        };
+                        Err(ApiError::new(format!("Unexpected response code {}:\n{:?}\n\n{}",
+                                                  code,
+                                                  headers,
+                                                  match result {
+                                                      Ok(_) => match str::from_utf8(&body) {
+                                                          Ok(body) => Cow::from(body),
+                                                          Err(e) => Cow::from(format!("<Body was not UTF8: {:?}>", e)),
+                                                      },
+                                                      Err(e) => Cow::from(format!("<Failed to read body: {}>", e)),
+                                                  }), err_type))
+                    }
+                }
+            })?;
+
         let mut hash = vec![0; 32];
         hash::Md::hash(mbedtls::hash::Type::Sha256,
-                                  raw_config.as_bytes(), &mut hash)
+                       raw_config.as_bytes(), &mut hash)
             .map_err(|e| ApiError::new(format!("Unable to hash app config: {}", e), SimpleErrorType::Permanent))?;
 
         if hash != expected_hash {
-            Err(ApiError::new(format!("App config hash mismatch."), SimpleErrorType::Permanent))
+            Err(ApiError::new("App config hash mismatch.".to_string(), SimpleErrorType::Permanent))
         } else {
             serde_json::from_str::<models::RuntimeAppConfig>(&raw_config)
                 .map_err(|e| e.into())
         }
-    }
-
-    fn get_runtime_application_config(&self) -> Result<models::RuntimeAppConfig, ApiError> {
-        self.get_runtime_application_config_raw()
-            .and_then(|body| {
-            serde_json::from_str::<models::RuntimeAppConfig>(&body)
-                .map_err(|e| e.into())
-        })
     }
 
     fn get_specific_runtime_application_config(&self, param_config_id: String) -> Result<models::RuntimeAppConfig, ApiError> {

--- a/em-client/src/client/mod.rs
+++ b/em-client/src/client/mod.rs
@@ -1405,7 +1405,7 @@ impl ApplicationConfigApi for Client {
 
     }
 
-    fn get_checked_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error> {
+    fn get_checked_runtime_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error> {
         let raw_config = self.get_runtime_application_config_raw()?;
         let mut hash = vec![0; 32];
         hash::Md::hash(mbedtls::hash::Type::Sha256,

--- a/em-client/src/client/mod.rs
+++ b/em-client/src/client/mod.rs
@@ -1405,7 +1405,7 @@ impl ApplicationConfigApi for Client {
 
     }
 
-    fn get_checked_runtime_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error> {
+    fn get_checked_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error> {
         let raw_config = self.get_runtime_application_config_raw()?;
         let mut hash = vec![0; 32];
         hash::Md::hash(mbedtls::hash::Type::Sha256,

--- a/em-client/src/lib.rs
+++ b/em-client/src/lib.rs
@@ -132,9 +132,6 @@ pub trait Api {
     /// Get app config
     fn get_runtime_application_config(&self) -> Result<models::RuntimeAppConfig, Self::Error>;
 
-    /// Get checked app config
-    fn get_checked_runtime_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error>;
-
     /// Get details of a particular runtime app config.
     fn get_specific_runtime_application_config(&self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error>;
 
@@ -463,9 +460,6 @@ pub trait ApiMut {
 
     /// Get app config
     fn get_runtime_application_config(&mut self) -> Result<models::RuntimeAppConfig, Self::Error>;
-
-    /// Get checked app config
-    fn get_checked_runtime_application_config(&mut self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error>;
 
     /// Get details of a particular runtime app config.
     fn get_specific_runtime_application_config(&mut self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error>;
@@ -840,10 +834,6 @@ where
     
         fn get_runtime_application_config(&self) -> Result<models::RuntimeAppConfig, Self::Error> {
             ApplicationConfigApi::get_runtime_application_config(self.0, )
-        }
-
-        fn get_checked_runtime_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error> {
-            ApplicationConfigApi::get_checked_runtime_application_config(self.0, expected_hash, )
         }
     
         fn get_specific_runtime_application_config(&self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error> {
@@ -1273,11 +1263,7 @@ where
         fn get_runtime_application_config(&self) -> Result<models::RuntimeAppConfig, Self::Error> {
             self.dispatch(|a| Api::get_runtime_application_config(a, ))
         }
-
-        fn get_checked_runtime_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error> {
-            self.dispatch(|a| Api::get_checked_runtime_application_config(a, expected_hash, ))
-        }
-
+    
         fn get_specific_runtime_application_config(&self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error> {
             self.dispatch(|a| Api::get_specific_runtime_application_config(a, config_id, ))
         }
@@ -1706,10 +1692,6 @@ where
         self.get_runtime_application_config()
     }
 
-    fn get_checked_runtime_application_config(&mut self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error> {
-        self.get_checked_runtime_application_config(expected_hash)
-    }
-
     fn get_specific_runtime_application_config(&mut self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error> {
         self.get_specific_runtime_application_config(config_id, )
     }
@@ -2134,10 +2116,6 @@ where
 
     fn get_runtime_application_config(&self) -> Result<models::RuntimeAppConfig, Self::Error> {
         self.borrow_mut().get_runtime_application_config()
-    }
-
-    fn get_checked_runtime_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error> {
-        self.borrow_mut().get_checked_runtime_application_config(expected_hash, )
     }
 
     fn get_specific_runtime_application_config(&self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error> {
@@ -2686,7 +2664,7 @@ pub trait ApplicationConfigApi {
     fn get_runtime_application_config(&self) -> Result<models::RuntimeAppConfig, Self::Error>;
 
     /// Get checked app config
-    fn get_checked_runtime_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error>;
+    fn get_checked_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error>;
 
     /// Get details of a particular runtime app config.
     fn get_specific_runtime_application_config(&self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error>;
@@ -2714,9 +2692,6 @@ pub trait ApplicationConfigApiMut {
 
     /// Get app config
     fn get_runtime_application_config(&mut self) -> Result<models::RuntimeAppConfig, Self::Error>;
-
-    /// Get checked app config
-    fn get_checked_runtime_application_config(&mut self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error>;
 
     /// Get details of a particular runtime app config.
     fn get_specific_runtime_application_config(&mut self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error>;
@@ -2752,10 +2727,6 @@ where
 
     fn get_runtime_application_config(&mut self) -> Result<models::RuntimeAppConfig, Self::Error> {
         <T as ApplicationConfigApi>::get_runtime_application_config(self, )
-    }
-
-    fn get_checked_runtime_application_config(&mut self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error> {
-        <T as ApplicationConfigApi>::get_checked_runtime_application_config(self, expected_hash)
     }
 
     fn get_specific_runtime_application_config(&mut self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error> {

--- a/em-client/src/lib.rs
+++ b/em-client/src/lib.rs
@@ -132,6 +132,9 @@ pub trait Api {
     /// Get app config
     fn get_runtime_application_config(&self) -> Result<models::RuntimeAppConfig, Self::Error>;
 
+    /// Get checked app config
+    fn get_checked_runtime_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error>;
+
     /// Get details of a particular runtime app config.
     fn get_specific_runtime_application_config(&self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error>;
 
@@ -460,6 +463,9 @@ pub trait ApiMut {
 
     /// Get app config
     fn get_runtime_application_config(&mut self) -> Result<models::RuntimeAppConfig, Self::Error>;
+
+    /// Get checked app config
+    fn get_checked_runtime_application_config(&mut self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error>;
 
     /// Get details of a particular runtime app config.
     fn get_specific_runtime_application_config(&mut self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error>;
@@ -834,6 +840,10 @@ where
     
         fn get_runtime_application_config(&self) -> Result<models::RuntimeAppConfig, Self::Error> {
             ApplicationConfigApi::get_runtime_application_config(self.0, )
+        }
+
+        fn get_checked_runtime_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error> {
+            ApplicationConfigApi::get_checked_runtime_application_config(self.0, expected_hash, )
         }
     
         fn get_specific_runtime_application_config(&self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error> {
@@ -1263,7 +1273,11 @@ where
         fn get_runtime_application_config(&self) -> Result<models::RuntimeAppConfig, Self::Error> {
             self.dispatch(|a| Api::get_runtime_application_config(a, ))
         }
-    
+
+        fn get_checked_runtime_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error> {
+            self.dispatch(|a| Api::get_checked_runtime_application_config(a, expected_hash, ))
+        }
+
         fn get_specific_runtime_application_config(&self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error> {
             self.dispatch(|a| Api::get_specific_runtime_application_config(a, config_id, ))
         }
@@ -1692,6 +1706,10 @@ where
         self.get_runtime_application_config()
     }
 
+    fn get_checked_runtime_application_config(&mut self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error> {
+        self.get_checked_runtime_application_config(expected_hash)
+    }
+
     fn get_specific_runtime_application_config(&mut self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error> {
         self.get_specific_runtime_application_config(config_id, )
     }
@@ -2116,6 +2134,10 @@ where
 
     fn get_runtime_application_config(&self) -> Result<models::RuntimeAppConfig, Self::Error> {
         self.borrow_mut().get_runtime_application_config()
+    }
+
+    fn get_checked_runtime_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error> {
+        self.borrow_mut().get_checked_runtime_application_config(expected_hash, )
     }
 
     fn get_specific_runtime_application_config(&self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error> {
@@ -2664,7 +2686,7 @@ pub trait ApplicationConfigApi {
     fn get_runtime_application_config(&self) -> Result<models::RuntimeAppConfig, Self::Error>;
 
     /// Get checked app config
-    fn get_checked_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error>;
+    fn get_checked_runtime_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error>;
 
     /// Get details of a particular runtime app config.
     fn get_specific_runtime_application_config(&self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error>;
@@ -2692,6 +2714,9 @@ pub trait ApplicationConfigApiMut {
 
     /// Get app config
     fn get_runtime_application_config(&mut self) -> Result<models::RuntimeAppConfig, Self::Error>;
+
+    /// Get checked app config
+    fn get_checked_runtime_application_config(&mut self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error>;
 
     /// Get details of a particular runtime app config.
     fn get_specific_runtime_application_config(&mut self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error>;
@@ -2727,6 +2752,10 @@ where
 
     fn get_runtime_application_config(&mut self) -> Result<models::RuntimeAppConfig, Self::Error> {
         <T as ApplicationConfigApi>::get_runtime_application_config(self, )
+    }
+
+    fn get_checked_runtime_application_config(&mut self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error> {
+        <T as ApplicationConfigApi>::get_checked_runtime_application_config(self, expected_hash)
     }
 
     fn get_specific_runtime_application_config(&mut self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error> {

--- a/em-client/src/lib.rs
+++ b/em-client/src/lib.rs
@@ -130,7 +130,7 @@ pub trait Api {
     fn get_application_config(&self, config_id: String) -> Result<models::ApplicationConfigResponse, Self::Error>;
 
     /// Get app config
-    fn get_runtime_application_config(&self) -> Result<models::RuntimeAppConfig, Self::Error>;
+    fn get_runtime_application_config(&self, expected_hash: &[u8; 32]) -> Result<models::RuntimeAppConfig, Self::Error>;
 
     /// Get details of a particular runtime app config.
     fn get_specific_runtime_application_config(&self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error>;
@@ -459,7 +459,7 @@ pub trait ApiMut {
     fn get_application_config(&mut self, config_id: String) -> Result<models::ApplicationConfigResponse, Self::Error>;
 
     /// Get app config
-    fn get_runtime_application_config(&mut self) -> Result<models::RuntimeAppConfig, Self::Error>;
+    fn get_runtime_application_config(&mut self, expected_hash: &[u8; 32]) -> Result<models::RuntimeAppConfig, Self::Error>;
 
     /// Get details of a particular runtime app config.
     fn get_specific_runtime_application_config(&mut self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error>;
@@ -832,8 +832,8 @@ where
             ApplicationConfigApi::get_application_config(self.0, config_id, )
         }
     
-        fn get_runtime_application_config(&self) -> Result<models::RuntimeAppConfig, Self::Error> {
-            ApplicationConfigApi::get_runtime_application_config(self.0, )
+        fn get_runtime_application_config(&self, expected_hash: &[u8; 32]) -> Result<models::RuntimeAppConfig, Self::Error> {
+            ApplicationConfigApi::get_runtime_application_config(self.0, expected_hash)
         }
     
         fn get_specific_runtime_application_config(&self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error> {
@@ -1260,8 +1260,8 @@ where
             self.dispatch(|a| Api::get_application_config(a, config_id, ))
         }
     
-        fn get_runtime_application_config(&self) -> Result<models::RuntimeAppConfig, Self::Error> {
-            self.dispatch(|a| Api::get_runtime_application_config(a, ))
+        fn get_runtime_application_config(&self, expected_hash: &[u8; 32]) -> Result<models::RuntimeAppConfig, Self::Error> {
+            self.dispatch(|a| Api::get_runtime_application_config(a, expected_hash))
         }
     
         fn get_specific_runtime_application_config(&self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error> {
@@ -1688,8 +1688,8 @@ where
         self.get_application_config(config_id, )
     }
 
-    fn get_runtime_application_config(&mut self) -> Result<models::RuntimeAppConfig, Self::Error> {
-        self.get_runtime_application_config()
+    fn get_runtime_application_config(&mut self, expected_hash: &[u8; 32]) -> Result<models::RuntimeAppConfig, Self::Error> {
+        self.get_runtime_application_config(expected_hash)
     }
 
     fn get_specific_runtime_application_config(&mut self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error> {
@@ -2114,8 +2114,8 @@ where
         self.borrow_mut().get_application_config(config_id, )
     }
 
-    fn get_runtime_application_config(&self) -> Result<models::RuntimeAppConfig, Self::Error> {
-        self.borrow_mut().get_runtime_application_config()
+    fn get_runtime_application_config(&self, expected_hash: &[u8; 32]) -> Result<models::RuntimeAppConfig, Self::Error> {
+        self.borrow_mut().get_runtime_application_config(expected_hash)
     }
 
     fn get_specific_runtime_application_config(&self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error> {
@@ -2661,10 +2661,7 @@ pub trait ApplicationConfigApi {
     fn get_application_config(&self, config_id: String) -> Result<models::ApplicationConfigResponse, Self::Error>;
 
     /// Get app config
-    fn get_runtime_application_config(&self) -> Result<models::RuntimeAppConfig, Self::Error>;
-
-    /// Get checked app config
-    fn get_checked_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error>;
+    fn get_runtime_application_config(&self, expected_hash: &[u8; 32]) -> Result<models::RuntimeAppConfig, Self::Error>;
 
     /// Get details of a particular runtime app config.
     fn get_specific_runtime_application_config(&self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error>;
@@ -2691,7 +2688,7 @@ pub trait ApplicationConfigApiMut {
     fn get_application_config(&mut self, config_id: String) -> Result<models::ApplicationConfigResponse, Self::Error>;
 
     /// Get app config
-    fn get_runtime_application_config(&mut self) -> Result<models::RuntimeAppConfig, Self::Error>;
+    fn get_runtime_application_config(&mut self, expected_hash: &[u8; 32]) -> Result<models::RuntimeAppConfig, Self::Error>;
 
     /// Get details of a particular runtime app config.
     fn get_specific_runtime_application_config(&mut self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error>;
@@ -2725,8 +2722,8 @@ where
         <T as ApplicationConfigApi>::get_application_config(self, config_id, )
     }
 
-    fn get_runtime_application_config(&mut self) -> Result<models::RuntimeAppConfig, Self::Error> {
-        <T as ApplicationConfigApi>::get_runtime_application_config(self, )
+    fn get_runtime_application_config(&mut self, expected_hash: &[u8; 32]) -> Result<models::RuntimeAppConfig, Self::Error> {
+        <T as ApplicationConfigApi>::get_runtime_application_config(self, expected_hash)
     }
 
     fn get_specific_runtime_application_config(&mut self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error> {

--- a/em-client/src/lib.rs
+++ b/em-client/src/lib.rs
@@ -27,6 +27,7 @@ extern crate serde_json;
 extern crate futures;
 extern crate chrono;
 extern crate uuid;
+extern crate mbedtls;
 
 use futures::Stream;
 use std::error;
@@ -2661,6 +2662,9 @@ pub trait ApplicationConfigApi {
 
     /// Get app config
     fn get_runtime_application_config(&self) -> Result<models::RuntimeAppConfig, Self::Error>;
+
+    /// Get checked app config
+    fn get_checked_application_config(&self, expected_hash: Vec<u8>) -> Result<models::RuntimeAppConfig, Self::Error>;
 
     /// Get details of a particular runtime app config.
     fn get_specific_runtime_application_config(&self, config_id: String) -> Result<models::RuntimeAppConfig, Self::Error>;

--- a/em-client/src/models.rs
+++ b/em-client/src/models.rs
@@ -862,7 +862,7 @@ impl ApplicationConfigConnectionDataset {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
 pub struct ApplicationConfigContents {
     #[serde(rename = "contents")]
@@ -919,7 +919,7 @@ impl ApplicationConfigExtra {
 
 
 /// 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
 pub struct ApplicationConfigPort {
     #[serde(rename = "dataset")]
@@ -929,7 +929,7 @@ pub struct ApplicationConfigPort {
     /// 
     #[serde(rename = "application")]
     #[serde(skip_serializing_if="Option::is_none")]
-    pub application: Option<String>,
+    pub application: Option<serde_json::Value>,
 
 }
 
@@ -944,7 +944,7 @@ impl ApplicationConfigPort {
 
 
 /// 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
 pub struct ApplicationConfigPortDataset {
     #[serde(rename = "id")]
@@ -1039,7 +1039,7 @@ impl ApplicationConfigSdkmsCredentials {
 
 
 /// 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
 pub struct ApplicationConfigWorkflow {
     #[serde(rename = "workflow_id")]
@@ -3631,7 +3631,7 @@ impl GetPckCertResponse {
 
 
 /// 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
 pub struct HashedConfig {
     #[serde(rename = "app_config")]

--- a/em-client/src/models.rs
+++ b/em-client/src/models.rs
@@ -862,7 +862,7 @@ impl ApplicationConfigConnectionDataset {
 }
 
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
 pub struct ApplicationConfigContents {
     #[serde(rename = "contents")]
@@ -919,7 +919,7 @@ impl ApplicationConfigExtra {
 
 
 /// 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
 pub struct ApplicationConfigPort {
     #[serde(rename = "dataset")]
@@ -929,7 +929,7 @@ pub struct ApplicationConfigPort {
     /// 
     #[serde(rename = "application")]
     #[serde(skip_serializing_if="Option::is_none")]
-    pub application: Option<serde_json::Value>,
+    pub application: Option<String>,
 
 }
 
@@ -944,7 +944,7 @@ impl ApplicationConfigPort {
 
 
 /// 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
 pub struct ApplicationConfigPortDataset {
     #[serde(rename = "id")]
@@ -1039,7 +1039,7 @@ impl ApplicationConfigSdkmsCredentials {
 
 
 /// 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
 pub struct ApplicationConfigWorkflow {
     #[serde(rename = "workflow_id")]
@@ -3631,7 +3631,7 @@ impl GetPckCertResponse {
 
 
 /// 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "conversion", derive(LabelledGeneric))]
 pub struct HashedConfig {
     #[serde(rename = "app_config")]


### PR DESCRIPTION
Adds `Hash` (https://doc.rust-lang.org/std/hash/index.html) implementation to a type that is used in `Salmiac` (https://github.com/fortanix/salmiac). This enables users of these structs to compute a hash value, ensuring the integrity of the struct.
To make the whole `HashedConfig` hashable I had  to change the type of `ApplicationConfigPort.application` from `serde::json` to `String` which bumps the `semver` version.






