### PR TITLE
[PROD-8063] New release of em-client `4.0.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "em-client"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "base64 0.10.1",
  "bitflags 1.3.2",
@@ -645,9 +645,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "mbedtls"
-version = "0.12.5"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85518d7740ddc73c8d4d07b1be49a73ab2f4b7658f05ee266bf1827c2b8e801a"
+checksum = "8b8114ab6c15889057a80479744eeb891e090ed2dd0258f13a7ef8ef02848293"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/em-client/Cargo.toml
+++ b/em-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "em-client"
-version = "4.0.0"
+version = "4.0.1"
 authors = ["Fortanix Inc."]
 license = "MPL-2.0"
 description = "This crate provides rust bindings for Enclave Manager API."
@@ -25,7 +25,7 @@ uuid = {version = "0.6", features = ["serde", "v4"]}
 hyper = {version = "0.10", default-features = false, optional = true}
 serde_ignored = {version = "0.0.4", optional = true}
 url = {version = "1.5", optional = true}
-mbedtls = { version = "0.12" }
+mbedtls = { version = ">=0.12.0, <0.14.0" }
 
 [dev-dependencies]
 clap = "2.25"


### PR DESCRIPTION
- bump version from 4.0.0 to 4.0.1
- Update `mbedtls` dependency to support mbedtls 0.13