### PR TITLE
Revert "Add support for new in Armor paths to em-client"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,9 +740,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "mbedtls"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8114ab6c15889057a80479744eeb891e090ed2dd0258f13a7ef8ef02848293"
+checksum = "6a545c48509913588baddc2fe51779e391e5992afd38be29f96d4831841fd303"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,22 +57,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 
 [[package]]
-name = "assert-json-diff"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,12 +173,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
 name = "cc"
 version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,7 +214,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -272,15 +250,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "colored"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -343,7 +312,7 @@ dependencies = [
  "clap",
  "crypto-hash",
  "em-client 2.0.0",
- "hyper 0.10.16",
+ "hyper",
  "hyper-native-tls",
  "lazy_static",
  "native-tls",
@@ -363,7 +332,7 @@ dependencies = [
  "base64 0.10.1",
  "chrono",
  "futures 0.1.31",
- "hyper 0.10.16",
+ "hyper",
  "lazy_static",
  "log 0.3.9",
  "mime 0.2.6",
@@ -377,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "em-client"
-version = "4.0.2"
+version = "4.0.1"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.4",
@@ -385,12 +354,11 @@ dependencies = [
  "clap",
  "error-chain",
  "futures 0.3.31",
- "hyper 0.10.16",
+ "hyper",
  "lazy_static",
  "log 0.4.28",
  "mbedtls",
  "mime 0.3.17",
- "mockito",
  "serde",
  "serde_derive",
  "serde_ignored 0.1.12",
@@ -408,7 +376,7 @@ dependencies = [
  "clap",
  "error-chain",
  "futures 0.3.31",
- "hyper 0.10.16",
+ "hyper",
  "lazy_static",
  "log 0.4.28",
  "mime 0.3.17",
@@ -419,12 +387,6 @@ dependencies = [
  "url",
  "uuid",
 ]
-
-[[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -453,12 +415,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,15 +428,6 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding 2.3.2",
-]
 
 [[package]]
 name = "fuchsia-cprng"
@@ -608,31 +555,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,49 +585,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
-dependencies = [
- "bytes",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "pin-project-lite",
-]
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
@@ -727,50 +610,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
-dependencies = [
- "atomic-waker",
- "bytes",
- "futures-channel",
- "futures-core",
- "h2",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "pin-utils",
- "smallvec",
- "tokio",
-]
-
-[[package]]
 name = "hyper-native-tls"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d375598f442742b0e66208ee12501391f1c7ac0bafb90b4fe53018f81f06068"
 dependencies = [
  "antidote",
- "hyper 0.10.16",
+ "hyper",
  "native-tls",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
-dependencies = [
- "bytes",
- "http",
- "http-body",
- "hyper 1.8.1",
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -806,16 +653,6 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
-dependencies = [
- "equivalent",
- "hashbrown",
 ]
 
 [[package]]
@@ -881,15 +718,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,9 +740,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "mbedtls"
-version = "0.13.5"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ab34e3a3b8eb0ed4dc157a65c001f5a9597e2a9aa580b7cab55c40cbdb375a"
+checksum = "8b8114ab6c15889057a80479744eeb891e090ed2dd0258f13a7ef8ef02848293"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
@@ -991,42 +819,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
-]
-
-[[package]]
-name = "mio"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
-dependencies = [
- "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "mockito"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
-dependencies = [
- "assert-json-diff",
- "bytes",
- "colored",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-util",
- "log 0.4.28",
- "pin-project-lite",
- "rand 0.9.2",
- "regex",
- "serde_json",
- "serde_urlencoded",
- "similar",
- "tokio",
 ]
 
 [[package]]
@@ -1155,29 +947,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if 1.0.1",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1188,12 +957,6 @@ name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-
-[[package]]
-name = "percent-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -1212,15 +975,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
 
 [[package]]
 name = "prettyplease"
@@ -1270,26 +1024,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,30 +1039,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 dependencies = [
  "rand_core 0.3.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -1445,12 +1161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1539,18 +1249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "sgx-isa"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,32 +1264,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-
-[[package]]
 name = "slab"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
-]
 
 [[package]]
 name = "strsim"
@@ -1670,53 +1346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokio"
-version = "1.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "parking_lot",
- "pin-project-lite",
- "socket2",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tracing"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
-dependencies = [
- "pin-project-lite",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "traitobject"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1772,7 +1401,7 @@ checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 dependencies = [
  "idna",
  "matches",
- "percent-encoding 1.0.1",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -1782,7 +1411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
 dependencies = [
  "cfg-if 0.1.10",
- "rand 0.4.6",
+ "rand",
  "serde",
 ]
 
@@ -1815,12 +1444,6 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1931,7 +1554,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.1.3",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
@@ -1965,18 +1588,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -1985,7 +1602,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -2004,15 +1621,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2160,26 +1768,6 @@ checksum = "79af3189e6b0484c9fd54208f8eeb8818cadee00ec81438b67a64c8e6f2f3694"
 dependencies = [
  "bit-vec",
  "num-bigint",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
 ]
 
 [[package]]

--- a/em-client/Cargo.toml
+++ b/em-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "em-client"
-version = "4.0.2"
+version = "4.0.1"
 authors = ["Fortanix Inc."]
 license = "MPL-2.0"
 description = "This crate provides rust bindings for Enclave Manager API."
@@ -25,9 +25,8 @@ uuid = {version = "0.6", features = ["serde", "v4"]}
 hyper = {version = "0.10", default-features = false, optional = true}
 serde_ignored = {version = "0.1.12", optional = true}
 url = {version = "1.5", optional = true}
-mbedtls = { version = ">=0.13.4, <0.14.0" }
+mbedtls = { version = ">=0.12.0, <0.14.0" }
 
 [dev-dependencies]
 clap = "2.25"
 error-chain = "0.12"
-mockito = "1.7.2"

--- a/em-client/src/client/mod.rs
+++ b/em-client/src/client/mod.rs
@@ -53,18 +53,6 @@ define_encode_set! {
     pub ID_ENCODE_SET = [PATH_SEGMENT_ENCODE_SET] | {'|'}
 }
 
-static NEW_FORMAT_UNSUPPORTED_CATEGORIES: [&'static str; 9] = [
-    "sys",
-    "session",
-    "user",
-    "users",
-    "accounts",
-    "admin",
-    "groups",
-    "third_party_groups",
-    "usage",
-];
-
 /// Convert input into a base path, e.g. "http://example:123". Also checks the scheme as it goes.
 fn into_base_path(
     input: &str,
@@ -92,7 +80,6 @@ pub struct Client {
     hyper_client: Arc<hyper::client::Client>,
     base_path: String,
     headers: Headers,
-    use_new_paths: bool,
 }
 
 impl fmt::Debug for Client {
@@ -107,7 +94,6 @@ impl Clone for Client {
             hyper_client: self.hyper_client.clone(),
             base_path: self.base_path.clone(),
             headers: self.headers.clone(),
-            use_new_paths: self.use_new_paths,
         }
     }
 }
@@ -151,7 +137,6 @@ impl Client {
             hyper_client: Arc::new(hyper_client),
             base_path: into_base_path(base_path, protocol)?,
             headers: Headers::new(),
-            use_new_paths: false,
         })
     }
 
@@ -176,47 +161,11 @@ impl Client {
             hyper_client: hyper_client,
             base_path: into_base_path(base_path, None)?,
             headers: Headers::new(),
-            use_new_paths: false,
         })
     }
 
     pub fn headers(&mut self) -> &mut Headers {
         &mut self.headers
-    }
-
-    pub fn use_new_paths(&self) -> bool {
-        self.use_new_paths
-    }
-
-    pub fn set_use_new_paths(&mut self, use_new_paths: bool) {
-        self.use_new_paths = use_new_paths;
-    }
-
-    pub fn with_new_paths(self) -> Self {
-        Self {
-            use_new_paths: true,
-            ..self
-        }
-    }
-
-    fn remap_operation_path(&self, operation: String) -> String {
-        if !self.use_new_paths {
-            return operation;
-        }
-        if let Some(path_without_v1) = operation.strip_prefix("/v1/") {
-            let api_category = if let Some((api_category, _)) = path_without_v1.split_once("/") {
-                api_category
-            } else {
-                path_without_v1
-            };
-
-            if NEW_FORMAT_UNSUPPORTED_CATEGORIES.contains(&api_category) {
-                return operation;
-            } else {
-                return format!("/api/v1/confidential_computing/{}", path_without_v1);
-            }
-        }
-        return operation;
     }
 }
 
@@ -227,12 +176,7 @@ impl AccountsApi for Client {
         &self,
         param_body: models::AccountRequest,
     ) -> Result<models::Account, ApiError> {
-        let operation_path = format!("/v1/accounts");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/accounts", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -318,14 +262,10 @@ impl AccountsApi for Client {
     }
 
     fn delete_account(&self, param_account_id: uuid::Uuid) -> Result<(), ApiError> {
-        let operation_path = format!(
-            "/v1/accounts/{account_id}",
-            account_id = utf8_percent_encode(&param_account_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/accounts/{account_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            account_id = utf8_percent_encode(&param_account_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -397,14 +337,10 @@ impl AccountsApi for Client {
     }
 
     fn get_account(&self, param_account_id: uuid::Uuid) -> Result<models::Account, ApiError> {
-        let operation_path = format!(
-            "/v1/accounts/{account_id}",
-            account_id = utf8_percent_encode(&param_account_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/accounts/{account_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            account_id = utf8_percent_encode(&param_account_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -484,12 +420,7 @@ impl AccountsApi for Client {
     }
 
     fn get_accounts(&self) -> Result<models::AccountListResponse, ApiError> {
-        let operation_path = format!("/v1/accounts");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/accounts", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -569,14 +500,10 @@ impl AccountsApi for Client {
     }
 
     fn select_account(&self, param_account_id: uuid::Uuid) -> Result<(), ApiError> {
-        let operation_path = format!(
-            "/v1/accounts/select_account/{account_id}",
-            account_id = utf8_percent_encode(&param_account_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/accounts/select_account/{account_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            account_id = utf8_percent_encode(&param_account_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -652,14 +579,10 @@ impl AccountsApi for Client {
         param_account_id: uuid::Uuid,
         param_body: models::AccountUpdateRequest,
     ) -> Result<models::Account, ApiError> {
-        let operation_path = format!(
-            "/v1/accounts/{account_id}",
-            account_id = utf8_percent_encode(&param_account_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/accounts/{account_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            account_id = utf8_percent_encode(&param_account_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -749,12 +672,7 @@ impl AppApi for Client {
     type Error = ApiError;
 
     fn add_application(&self, param_body: models::AppRequest) -> Result<models::App, ApiError> {
-        let operation_path = format!("/v1/apps");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/apps", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -840,14 +758,10 @@ impl AppApi for Client {
     }
 
     fn delete_app(&self, param_app_id: uuid::Uuid) -> Result<(), ApiError> {
-        let operation_path = format!(
-            "/v1/apps/{app_id}",
-            app_id = utf8_percent_encode(&param_app_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/apps/{app_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            app_id = utf8_percent_encode(&param_app_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -927,12 +841,7 @@ impl AppApi for Client {
         param_offset: Option<i32>,
         param_sort_by: Option<String>,
     ) -> Result<models::GetAllAppsResponse, ApiError> {
-        let operation_path = format!("/v1/apps");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/apps", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -1030,14 +939,10 @@ impl AppApi for Client {
     }
 
     fn get_app(&self, param_app_id: uuid::Uuid) -> Result<models::App, ApiError> {
-        let operation_path = format!(
-            "/v1/apps/{app_id}",
-            app_id = utf8_percent_encode(&param_app_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/apps/{app_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            app_id = utf8_percent_encode(&param_app_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -1121,15 +1026,11 @@ impl AppApi for Client {
         param_node_id: uuid::Uuid,
         param_app_id: uuid::Uuid,
     ) -> Result<models::Certificate, ApiError> {
-        let operation_path = format!(
-            "/v1/apps/{app_id}/node/{node_id}/certificate",
+        let mut url = format!(
+            "{}/v1/apps/{app_id}/node/{node_id}/certificate",
+            self.base_path,
             node_id = utf8_percent_encode(&param_node_id.to_string(), ID_ENCODE_SET),
             app_id = utf8_percent_encode(&param_app_id.to_string(), ID_ENCODE_SET)
-        );
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -1213,16 +1114,13 @@ impl AppApi for Client {
         param_node_id: uuid::Uuid,
         param_app_id: uuid::Uuid,
     ) -> Result<models::CertificateDetails, ApiError> {
-        let operation_path = format!(
-            "/v1/apps/{app_id}/node/{node_id}/certificate-details",
+        let mut url = format!(
+            "{}/v1/apps/{app_id}/node/{node_id}/certificate-details",
+            self.base_path,
             node_id = utf8_percent_encode(&param_node_id.to_string(), ID_ENCODE_SET),
             app_id = utf8_percent_encode(&param_app_id.to_string(), ID_ENCODE_SET)
         );
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
         let query_string_str = query_string.finish();
@@ -1301,12 +1199,8 @@ impl AppApi for Client {
     }
 
     fn get_apps_unique_labels(&self) -> Result<models::LabelsCount, ApiError> {
-        let operation_path = format!("/v1/apps/unique_labels/count");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/apps/unique_labels/count", self.base_path);
+
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
         let query_string_str = query_string.finish();
@@ -1388,14 +1282,10 @@ impl AppApi for Client {
         param_app_id: uuid::Uuid,
         param_body: models::AppBodyUpdateRequest,
     ) -> Result<models::App, ApiError> {
-        let operation_path = format!(
-            "/v1/apps/{app_id}",
-            app_id = utf8_percent_encode(&param_app_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/apps/{app_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            app_id = utf8_percent_encode(&param_app_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -1488,12 +1378,7 @@ impl ApplicationConfigApi for Client {
         &self,
         param_body: models::ApplicationConfig,
     ) -> Result<models::ApplicationConfigResponse, ApiError> {
-        let operation_path = format!("/v1/app_configs");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/app_configs", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -1582,14 +1467,10 @@ impl ApplicationConfigApi for Client {
     }
 
     fn delete_application_config(&self, param_config_id: String) -> Result<(), ApiError> {
-        let operation_path = format!(
-            "/v1/app_configs/{config_id}",
-            config_id = utf8_percent_encode(&param_config_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/app_configs/{config_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            config_id = utf8_percent_encode(&param_config_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -1668,12 +1549,7 @@ impl ApplicationConfigApi for Client {
         param_limit: Option<i32>,
         param_offset: Option<i32>,
     ) -> Result<models::GetAllApplicationConfigsResponse, ApiError> {
-        let operation_path = format!("/v1/app_configs");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/app_configs", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -1771,14 +1647,10 @@ impl ApplicationConfigApi for Client {
         &self,
         param_config_id: String,
     ) -> Result<models::ApplicationConfigResponse, ApiError> {
-        let operation_path = format!(
-            "/v1/app_configs/{config_id}",
-            config_id = utf8_percent_encode(&param_config_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/app_configs/{config_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            config_id = utf8_percent_encode(&param_config_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -1862,12 +1734,7 @@ impl ApplicationConfigApi for Client {
         &self,
         expected_hash: &[u8; 32],
     ) -> Result<models::RuntimeAppConfig, ApiError> {
-        let operation_path = format!("/v1/runtime/app_configs");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/runtime/app_configs", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -1947,14 +1814,10 @@ impl ApplicationConfigApi for Client {
         &self,
         param_config_id: String,
     ) -> Result<models::RuntimeAppConfig, ApiError> {
-        let operation_path = format!(
-            "/v1/runtime/app_configs/{config_id}",
-            config_id = utf8_percent_encode(&param_config_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/runtime/app_configs/{config_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            config_id = utf8_percent_encode(&param_config_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -2039,14 +1902,10 @@ impl ApplicationConfigApi for Client {
         param_config_id: String,
         param_body: models::UpdateApplicationConfigRequest,
     ) -> Result<models::ApplicationConfigResponse, ApiError> {
-        let operation_path = format!(
-            "/v1/app_configs/{config_id}",
-            config_id = utf8_percent_encode(&param_config_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/app_configs/{config_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            config_id = utf8_percent_encode(&param_config_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -2143,14 +2002,10 @@ impl ApprovalRequestsApi for Client {
         param_request_id: uuid::Uuid,
         param_body: Option<models::ApproveRequest>,
     ) -> Result<models::ApprovalRequest, ApiError> {
-        let operation_path = format!(
-            "/v1/approval_requests/{request_id}/approve",
-            request_id = utf8_percent_encode(&param_request_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/approval_requests/{request_id}/approve",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            request_id = utf8_percent_encode(&param_request_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -2248,12 +2103,7 @@ impl ApprovalRequestsApi for Client {
         &self,
         param_body: models::ApprovalRequestRequest,
     ) -> Result<models::ApprovalRequest, ApiError> {
-        let operation_path = format!("/v1/approval_requests");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/approval_requests", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -2341,14 +2191,10 @@ impl ApprovalRequestsApi for Client {
     }
 
     fn delete_approval_request(&self, param_request_id: uuid::Uuid) -> Result<(), ApiError> {
-        let operation_path = format!(
-            "/v1/approval_requests/{request_id}",
-            request_id = utf8_percent_encode(&param_request_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/approval_requests/{request_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            request_id = utf8_percent_encode(&param_request_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -2424,14 +2270,10 @@ impl ApprovalRequestsApi for Client {
         param_request_id: uuid::Uuid,
         param_body: Option<models::DenyRequest>,
     ) -> Result<models::ApprovalRequest, ApiError> {
-        let operation_path = format!(
-            "/v1/approval_requests/{request_id}/deny",
-            request_id = utf8_percent_encode(&param_request_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/approval_requests/{request_id}/deny",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            request_id = utf8_percent_encode(&param_request_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -2535,12 +2377,7 @@ impl ApprovalRequestsApi for Client {
         param_limit: Option<i32>,
         param_offset: Option<i32>,
     ) -> Result<models::GetAllApprovalRequests, ApiError> {
-        let operation_path = format!("/v1/approval_requests");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/approval_requests", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -2647,14 +2484,10 @@ impl ApprovalRequestsApi for Client {
         &self,
         param_request_id: uuid::Uuid,
     ) -> Result<models::ApprovalRequest, ApiError> {
-        let operation_path = format!(
-            "/v1/approval_requests/{request_id}",
-            request_id = utf8_percent_encode(&param_request_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/approval_requests/{request_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            request_id = utf8_percent_encode(&param_request_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -2738,14 +2571,10 @@ impl ApprovalRequestsApi for Client {
         &self,
         param_request_id: uuid::Uuid,
     ) -> Result<models::ApprovableResult, ApiError> {
-        let operation_path = format!(
-            "/v1/approval_requests/{request_id}/result",
-            request_id = utf8_percent_encode(&param_request_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/approval_requests/{request_id}/result",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            request_id = utf8_percent_encode(&param_request_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -2833,12 +2662,7 @@ impl AuthApi for Client {
         &self,
         param_body: Option<models::AuthRequest>,
     ) -> Result<models::AuthResponse, ApiError> {
-        let operation_path = format!("/v1/sys/auth");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/sys/auth", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -2936,12 +2760,7 @@ impl BuildApi for Client {
         &self,
         param_body: models::ConvertAppBuildRequest,
     ) -> Result<models::Build, ApiError> {
-        let operation_path = format!("/v1/builds/convert-app/aci");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/builds/convert-app", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -3030,12 +2849,7 @@ impl BuildApi for Client {
         &self,
         param_body: models::CreateBuildRequest,
     ) -> Result<models::Build, ApiError> {
-        let operation_path = format!("/v1/builds");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/builds", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -3120,14 +2934,10 @@ impl BuildApi for Client {
     }
 
     fn delete_build(&self, param_build_id: uuid::Uuid) -> Result<(), ApiError> {
-        let operation_path = format!(
-            "/v1/builds/{build_id}",
-            build_id = utf8_percent_encode(&param_build_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/builds/{build_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            build_id = utf8_percent_encode(&param_build_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -3209,12 +3019,7 @@ impl BuildApi for Client {
         param_offset: Option<i32>,
         param_sort_by: Option<String>,
     ) -> Result<models::GetAllBuildsResponse, ApiError> {
-        let operation_path = format!("/v1/builds");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/builds", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -3318,14 +3123,10 @@ impl BuildApi for Client {
     }
 
     fn get_build(&self, param_build_id: uuid::Uuid) -> Result<models::Build, ApiError> {
-        let operation_path = format!(
-            "/v1/builds/{build_id}",
-            build_id = utf8_percent_encode(&param_build_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/builds/{build_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            build_id = utf8_percent_encode(&param_build_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -3413,14 +3214,10 @@ impl BuildApi for Client {
         param_limit: Option<i32>,
         param_offset: Option<i32>,
     ) -> Result<models::GetAllBuildDeploymentsResponse, ApiError> {
-        let operation_path = format!(
-            "/v1/builds/deployments/{build_id}",
-            build_id = utf8_percent_encode(&param_build_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/builds/deployments/{build_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            build_id = utf8_percent_encode(&param_build_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -3520,14 +3317,10 @@ impl BuildApi for Client {
         param_build_id: uuid::Uuid,
         param_body: models::BuildUpdateRequest,
     ) -> Result<models::Build, ApiError> {
-        let operation_path = format!(
-            "/v1/builds/{build_id}",
-            build_id = utf8_percent_encode(&param_build_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/builds/{build_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            build_id = utf8_percent_encode(&param_build_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -3617,14 +3410,10 @@ impl CertificateApi for Client {
     type Error = ApiError;
 
     fn get_certificate(&self, param_cert_id: uuid::Uuid) -> Result<models::Certificate, ApiError> {
-        let operation_path = format!(
-            "/v1/certificates/{cert_id}",
-            cert_id = utf8_percent_encode(&param_cert_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/certificates/{cert_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            cert_id = utf8_percent_encode(&param_cert_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -3707,12 +3496,7 @@ impl CertificateApi for Client {
         &self,
         param_body: models::NewCertificateRequest,
     ) -> Result<models::TaskResult, ApiError> {
-        let operation_path = format!("/v1/certificates");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/certificates", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -3804,12 +3588,7 @@ impl DatasetApi for Client {
         &self,
         param_body: models::CreateDatasetRequest,
     ) -> Result<models::Dataset, ApiError> {
-        let operation_path = format!("/v1/datasets");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/datasets", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -3895,14 +3674,10 @@ impl DatasetApi for Client {
     }
 
     fn delete_dataset(&self, param_dataset_id: uuid::Uuid) -> Result<(), ApiError> {
-        let operation_path = format!(
-            "/v1/datasets/{dataset_id}",
-            dataset_id = utf8_percent_encode(&param_dataset_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/datasets/{dataset_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            dataset_id = utf8_percent_encode(&param_dataset_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -3980,12 +3755,7 @@ impl DatasetApi for Client {
         param_limit: Option<i32>,
         param_offset: Option<i32>,
     ) -> Result<models::GetAllDatasetsResponse, ApiError> {
-        let operation_path = format!("/v1/datasets");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/datasets", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -4077,14 +3847,10 @@ impl DatasetApi for Client {
     }
 
     fn get_dataset(&self, param_dataset_id: uuid::Uuid) -> Result<models::Dataset, ApiError> {
-        let operation_path = format!(
-            "/v1/datasets/{dataset_id}",
-            dataset_id = utf8_percent_encode(&param_dataset_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/datasets/{dataset_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            dataset_id = utf8_percent_encode(&param_dataset_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -4168,14 +3934,10 @@ impl DatasetApi for Client {
         param_dataset_id: uuid::Uuid,
         param_body: models::DatasetUpdateRequest,
     ) -> Result<models::Dataset, ApiError> {
-        let operation_path = format!(
-            "/v1/datasets/{dataset_id}",
-            dataset_id = utf8_percent_encode(&param_dataset_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/datasets/{dataset_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            dataset_id = utf8_percent_encode(&param_dataset_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -4265,14 +4027,10 @@ impl NodeApi for Client {
     type Error = ApiError;
 
     fn deactivate_node(&self, param_node_id: uuid::Uuid) -> Result<(), ApiError> {
-        let operation_path = format!(
-            "/v1/nodes/{node_id}/deactivate",
-            node_id = utf8_percent_encode(&param_node_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/nodes/{node_id}/deactivate",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            node_id = utf8_percent_encode(&param_node_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -4354,12 +4112,7 @@ impl NodeApi for Client {
         param_offset: Option<i32>,
         param_sort_by: Option<String>,
     ) -> Result<models::GetAllNodesResponse, ApiError> {
-        let operation_path = format!("/v1/nodes");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/nodes", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -4463,14 +4216,10 @@ impl NodeApi for Client {
     }
 
     fn get_node(&self, param_node_id: uuid::Uuid) -> Result<models::Node, ApiError> {
-        let operation_path = format!(
-            "/v1/nodes/{node_id}",
-            node_id = utf8_percent_encode(&param_node_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/nodes/{node_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            node_id = utf8_percent_encode(&param_node_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -4553,14 +4302,10 @@ impl NodeApi for Client {
         &self,
         param_node_id: uuid::Uuid,
     ) -> Result<models::Certificate, ApiError> {
-        let operation_path = format!(
-            "/v1/nodes/{node_id}/certificate",
-            node_id = utf8_percent_encode(&param_node_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/nodes/{node_id}/certificate",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            node_id = utf8_percent_encode(&param_node_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -4643,14 +4388,10 @@ impl NodeApi for Client {
         &self,
         param_node_id: uuid::Uuid,
     ) -> Result<models::CertificateDetails, ApiError> {
-        let operation_path = format!(
-            "/v1/nodes/{node_id}/certificate-details",
-            node_id = utf8_percent_encode(&param_node_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/nodes/{node_id}/certificate-details",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            node_id = utf8_percent_encode(&param_node_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -4731,12 +4472,7 @@ impl NodeApi for Client {
     }
 
     fn get_nodes_unique_labels(&self) -> Result<models::LabelsCount, ApiError> {
-        let operation_path = format!("/v1/nodes/unique_labels/count");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/nodes/unique_labels/count", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -4818,12 +4554,7 @@ impl NodeApi for Client {
         &self,
         param_body: models::NodeProvisionRequest,
     ) -> Result<models::TaskResult, ApiError> {
-        let operation_path = format!("/v1/nodes");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/nodes", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -4912,14 +4643,10 @@ impl NodeApi for Client {
         param_node_id: uuid::Uuid,
         param_body: models::NodeUpdateRequest,
     ) -> Result<models::Node, ApiError> {
-        let operation_path = format!(
-            "/v1/nodes/{node_id}",
-            node_id = utf8_percent_encode(&param_node_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/nodes/{node_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            node_id = utf8_percent_encode(&param_node_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -5008,12 +4735,7 @@ impl NodeApi for Client {
         &self,
         param_body: models::NodeStatusRequest,
     ) -> Result<models::NodeStatusResponse, ApiError> {
-        let operation_path = format!("/v1/node/status");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/node/status", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -5106,12 +4828,7 @@ impl RegistryApi for Client {
         &self,
         param_registry_request: models::RegistryRequest,
     ) -> Result<models::Registry, ApiError> {
-        let operation_path = format!("/v1/registry");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/registry", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -5197,14 +4914,10 @@ impl RegistryApi for Client {
     }
 
     fn delete_registry(&self, param_registry_id: uuid::Uuid) -> Result<(), ApiError> {
-        let operation_path = format!(
-            "/v1/registry/{registry_id}",
-            registry_id = utf8_percent_encode(&param_registry_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/registry/{registry_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            registry_id = utf8_percent_encode(&param_registry_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -5276,12 +4989,7 @@ impl RegistryApi for Client {
     }
 
     fn get_all_registries(&self) -> Result<Vec<models::Registry>, ApiError> {
-        let operation_path = format!("/v1/registry");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/registry", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -5361,14 +5069,10 @@ impl RegistryApi for Client {
     }
 
     fn get_registry(&self, param_registry_id: uuid::Uuid) -> Result<models::Registry, ApiError> {
-        let operation_path = format!(
-            "/v1/registry/{registry_id}",
-            registry_id = utf8_percent_encode(&param_registry_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/registry/{registry_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            registry_id = utf8_percent_encode(&param_registry_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -5451,14 +5155,10 @@ impl RegistryApi for Client {
         &self,
         param_app_id: uuid::Uuid,
     ) -> Result<models::AppRegistryResponse, ApiError> {
-        let operation_path = format!(
-            "/v1/registry/app/{app_id}",
-            app_id = utf8_percent_encode(&param_app_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/registry/app/{app_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            app_id = utf8_percent_encode(&param_app_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -5542,12 +5242,7 @@ impl RegistryApi for Client {
         &self,
         param_image_name: String,
     ) -> Result<models::ImageRegistryResponse, ApiError> {
-        let operation_path = format!("/v1/image/registry");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/image/registry", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
         query_string.append_pair("image_name", &param_image_name.to_string());
@@ -5632,14 +5327,10 @@ impl RegistryApi for Client {
         param_registry_id: uuid::Uuid,
         param_body: models::UpdateRegistryRequest,
     ) -> Result<models::Registry, ApiError> {
-        let operation_path = format!(
-            "/v1/registry/{registry_id}",
-            registry_id = utf8_percent_encode(&param_registry_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/registry/{registry_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            registry_id = utf8_percent_encode(&param_registry_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -5729,12 +5420,7 @@ impl SystemApi for Client {
     type Error = ApiError;
 
     fn get_manager_version(&self) -> Result<models::VersionResponse, ApiError> {
-        let operation_path = format!("/v1/sys/version");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/sys/version", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -5829,12 +5515,7 @@ impl TaskApi for Client {
         param_sort_by: Option<String>,
         param_base_filters: Option<String>,
     ) -> Result<models::GetAllTasksResponse, ApiError> {
-        let operation_path = format!("/v1/tasks");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/tasks", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -5941,14 +5622,10 @@ impl TaskApi for Client {
     }
 
     fn get_task(&self, param_task_id: uuid::Uuid) -> Result<models::Task, ApiError> {
-        let operation_path = format!(
-            "/v1/tasks/{task_id}",
-            task_id = utf8_percent_encode(&param_task_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/tasks/{task_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            task_id = utf8_percent_encode(&param_task_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -6028,14 +5705,10 @@ impl TaskApi for Client {
     }
 
     fn get_task_status(&self, param_task_id: uuid::Uuid) -> Result<models::TaskResult, ApiError> {
-        let operation_path = format!(
-            "/v1/tasks/status/{task_id}",
-            task_id = utf8_percent_encode(&param_task_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/tasks/status/{task_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            task_id = utf8_percent_encode(&param_task_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -6119,14 +5792,10 @@ impl TaskApi for Client {
         param_task_id: uuid::Uuid,
         param_body: models::TaskUpdateRequest,
     ) -> Result<models::TaskResult, ApiError> {
-        let operation_path = format!(
-            "/v1/tasks/{task_id}",
-            task_id = utf8_percent_encode(&param_task_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/tasks/{task_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            task_id = utf8_percent_encode(&param_task_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -6219,12 +5888,7 @@ impl ToolsApi for Client {
         &self,
         param_body: models::ConversionRequest,
     ) -> Result<models::ConversionResponse, ApiError> {
-        let operation_path = format!("/v1/tools/converter/convert-app");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/tools/converter/convert-app", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -6315,12 +5979,7 @@ impl UsersApi for Client {
     type Error = ApiError;
 
     fn accept_terms_and_conditions(&self) -> Result<(), ApiError> {
-        let operation_path = format!("/v1/users/terms_and_conditions");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/users/terms_and_conditions", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -6391,12 +6050,7 @@ impl UsersApi for Client {
     }
 
     fn change_password(&self, param_body: models::PasswordChangeRequest) -> Result<(), ApiError> {
-        let operation_path = format!("/v1/users/change_password");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/users/change_password", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -6476,12 +6130,7 @@ impl UsersApi for Client {
         &self,
         param_body: models::ConfirmEmailRequest,
     ) -> Result<models::ConfirmEmailResponse, ApiError> {
-        let operation_path = format!("/v1/users/confirm_email");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/users/confirm_email", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -6567,12 +6216,7 @@ impl UsersApi for Client {
     }
 
     fn create_user(&self, param_body: models::SignupRequest) -> Result<models::User, ApiError> {
-        let operation_path = format!("/v1/users");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/users", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -6657,15 +6301,12 @@ impl UsersApi for Client {
     }
 
     fn delete_user_account(&self, param_user_id: uuid::Uuid) -> Result<(), ApiError> {
-        let operation_path = format!(
-            "/v1/users/{user_id}",
+        let mut url = format!(
+            "{}/v1/users/{user_id}",
+            self.base_path,
             user_id = utf8_percent_encode(&param_user_id.to_string(), ID_ENCODE_SET)
         );
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
         let query_string_str = query_string.finish();
@@ -6735,14 +6376,10 @@ impl UsersApi for Client {
     }
 
     fn delete_user_from_account(&self, param_user_id: uuid::Uuid) -> Result<(), ApiError> {
-        let operation_path = format!(
-            "/v1/users/{user_id}/accounts",
-            user_id = utf8_percent_encode(&param_user_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/users/{user_id}/accounts",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            user_id = utf8_percent_encode(&param_user_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -6814,12 +6451,7 @@ impl UsersApi for Client {
     }
 
     fn forgot_password(&self, param_body: models::ForgotPasswordRequest) -> Result<(), ApiError> {
-        let operation_path = format!("/v1/users/forgot_password");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/users/forgot_password", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -6902,12 +6534,7 @@ impl UsersApi for Client {
         param_offset: Option<i32>,
         param_sort_by: Option<String>,
     ) -> Result<models::GetAllUsersResponse, ApiError> {
-        let operation_path = format!("/v1/users");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/users", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -6999,12 +6626,7 @@ impl UsersApi for Client {
     }
 
     fn get_logged_in_user(&self) -> Result<models::User, ApiError> {
-        let operation_path = format!("/v1/user");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/user", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -7083,14 +6705,10 @@ impl UsersApi for Client {
     }
 
     fn get_user(&self, param_user_id: uuid::Uuid) -> Result<models::User, ApiError> {
-        let operation_path = format!(
-            "/v1/users/{user_id}",
-            user_id = utf8_percent_encode(&param_user_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/users/{user_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            user_id = utf8_percent_encode(&param_user_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -7170,12 +6788,7 @@ impl UsersApi for Client {
     }
 
     fn invite_user(&self, param_body: models::InviteUserRequest) -> Result<models::User, ApiError> {
-        let operation_path = format!("/v1/users/invite");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/users/invite", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -7263,12 +6876,7 @@ impl UsersApi for Client {
         &self,
         param_body: models::ProcessInviteRequest,
     ) -> Result<(), ApiError> {
-        let operation_path = format!("/v1/users/process_invite");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/users/process_invite", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -7347,12 +6955,7 @@ impl UsersApi for Client {
     }
 
     fn resend_confirm_email(&self) -> Result<(), ApiError> {
-        let operation_path = format!("/v1/users/resend_confirm_email");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/users/resend_confirm_email", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -7423,14 +7026,10 @@ impl UsersApi for Client {
     }
 
     fn resend_invitation(&self, param_user_id: uuid::Uuid) -> Result<(), ApiError> {
-        let operation_path = format!(
-            "/v1/users/{user_id}/resend_invite",
-            user_id = utf8_percent_encode(&param_user_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/users/{user_id}/resend_invite",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            user_id = utf8_percent_encode(&param_user_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -7506,14 +7105,10 @@ impl UsersApi for Client {
         param_user_id: uuid::Uuid,
         param_body: models::PasswordResetRequest,
     ) -> Result<(), ApiError> {
-        let operation_path = format!(
-            "/v1/users/{user_id}/reset_password",
-            user_id = utf8_percent_encode(&param_user_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/users/{user_id}/reset_password",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            user_id = utf8_percent_encode(&param_user_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -7595,14 +7190,10 @@ impl UsersApi for Client {
         param_user_id: uuid::Uuid,
         param_body: models::UpdateUserRequest,
     ) -> Result<models::User, ApiError> {
-        let operation_path = format!(
-            "/v1/users/{user_id}",
-            user_id = utf8_percent_encode(&param_user_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/users/{user_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            user_id = utf8_percent_encode(&param_user_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -7692,14 +7283,10 @@ impl UsersApi for Client {
         param_user_id: uuid::Uuid,
         param_body: models::ValidateTokenRequest,
     ) -> Result<models::ValidateTokenResponse, ApiError> {
-        let operation_path = format!(
-            "/v1/users/{user_id}/validate_token",
-            user_id = utf8_percent_encode(&param_user_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/users/{user_id}/validate_token",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            user_id = utf8_percent_encode(&param_user_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -7795,12 +7382,7 @@ impl WorkflowApi for Client {
         &self,
         param_body: models::CreateWorkflowGraph,
     ) -> Result<models::WorkflowGraph, ApiError> {
-        let operation_path = format!("/v1/workflows/draft/graphs");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/workflows/draft/graphs", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -7889,14 +7471,10 @@ impl WorkflowApi for Client {
     }
 
     fn delete_workflow_graph(&self, param_graph_id: uuid::Uuid) -> Result<(), ApiError> {
-        let operation_path = format!(
-            "/v1/workflows/draft/graphs/{graph_id}",
-            graph_id = utf8_percent_encode(&param_graph_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/workflows/draft/graphs/{graph_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            graph_id = utf8_percent_encode(&param_graph_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -7977,12 +7555,7 @@ impl WorkflowApi for Client {
         param_limit: Option<i32>,
         param_offset: Option<i32>,
     ) -> Result<models::GetAllWorkflowGraphsResponse, ApiError> {
-        let operation_path = format!("/v1/workflows/draft/graphs");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/workflows/draft/graphs", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -8086,14 +7659,10 @@ impl WorkflowApi for Client {
         &self,
         param_graph_id: uuid::Uuid,
     ) -> Result<models::WorkflowGraph, ApiError> {
-        let operation_path = format!(
-            "/v1/workflows/draft/graphs/{graph_id}",
-            graph_id = utf8_percent_encode(&param_graph_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/workflows/draft/graphs/{graph_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            graph_id = utf8_percent_encode(&param_graph_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -8178,14 +7747,10 @@ impl WorkflowApi for Client {
         param_graph_id: uuid::Uuid,
         param_body: models::UpdateWorkflowGraph,
     ) -> Result<models::WorkflowGraph, ApiError> {
-        let operation_path = format!(
-            "/v1/workflows/draft/graphs/{graph_id}",
-            graph_id = utf8_percent_encode(&param_graph_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/workflows/draft/graphs/{graph_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            graph_id = utf8_percent_encode(&param_graph_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -8281,12 +7846,7 @@ impl WorkflowFinalApi for Client {
         &self,
         param_body: models::CreateFinalWorkflowGraph,
     ) -> Result<models::FinalWorkflow, ApiError> {
-        let operation_path = format!("/v1/workflows/final/graphs");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/workflows/final/graphs", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -8379,15 +7939,11 @@ impl WorkflowFinalApi for Client {
         param_graph_id: uuid::Uuid,
         param_version: String,
     ) -> Result<(), ApiError> {
-        let operation_path = format!(
-            "/v1/workflows/final/graphs/{graph_id}/{version}",
+        let mut url = format!(
+            "{}/v1/workflows/final/graphs/{graph_id}/{version}",
+            self.base_path,
             graph_id = utf8_percent_encode(&param_graph_id.to_string(), ID_ENCODE_SET),
             version = utf8_percent_encode(&param_version.to_string(), ID_ENCODE_SET)
-        );
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -8467,12 +8023,7 @@ impl WorkflowFinalApi for Client {
         param_limit: Option<i32>,
         param_offset: Option<i32>,
     ) -> Result<models::GetAllFinalWorkflowGraphsResponse, ApiError> {
-        let operation_path = format!("/v1/workflows/final/graphs");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/workflows/final/graphs", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -8574,15 +8125,11 @@ impl WorkflowFinalApi for Client {
         param_graph_id: uuid::Uuid,
         param_version: String,
     ) -> Result<models::VersionInFinalWorkflow, ApiError> {
-        let operation_path = format!(
-            "/v1/workflows/final/graphs/{graph_id}/{version}",
+        let mut url = format!(
+            "{}/v1/workflows/final/graphs/{graph_id}/{version}",
+            self.base_path,
             graph_id = utf8_percent_encode(&param_graph_id.to_string(), ID_ENCODE_SET),
             version = utf8_percent_encode(&param_version.to_string(), ID_ENCODE_SET)
-        );
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -8666,14 +8213,10 @@ impl WorkflowFinalApi for Client {
         &self,
         param_graph_id: uuid::Uuid,
     ) -> Result<models::FinalWorkflow, ApiError> {
-        let operation_path = format!(
-            "/v1/workflows/final/graphs/{graph_id}",
-            graph_id = utf8_percent_encode(&param_graph_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/workflows/final/graphs/{graph_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            graph_id = utf8_percent_encode(&param_graph_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -8758,14 +8301,10 @@ impl WorkflowFinalApi for Client {
         param_graph_id: uuid::Uuid,
         param_body: models::CreateWorkflowVersionRequest,
     ) -> Result<models::VersionInFinalWorkflow, ApiError> {
-        let operation_path = format!(
-            "/v1/workflows/final/graphs/{graph_id}",
-            graph_id = utf8_percent_encode(&param_graph_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/workflows/final/graphs/{graph_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            graph_id = utf8_percent_encode(&param_graph_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -8858,14 +8397,10 @@ impl ZoneApi for Client {
     type Error = ApiError;
 
     fn get_zone(&self, param_zone_id: uuid::Uuid) -> Result<models::Zone, ApiError> {
-        let operation_path = format!(
-            "/v1/zones/{zone_id}",
-            zone_id = utf8_percent_encode(&param_zone_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/zones/{zone_id}",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            zone_id = utf8_percent_encode(&param_zone_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -8948,14 +8483,10 @@ impl ZoneApi for Client {
         &self,
         param_zone_id: uuid::Uuid,
     ) -> Result<models::ZoneJoinToken, ApiError> {
-        let operation_path = format!(
-            "/v1/zones/{zone_id}/token",
-            zone_id = utf8_percent_encode(&param_zone_id.to_string(), ID_ENCODE_SET)
-        );
         let mut url = format!(
-            "{}{}",
+            "{}/v1/zones/{zone_id}/token",
             self.base_path,
-            self.remap_operation_path(operation_path)
+            zone_id = utf8_percent_encode(&param_zone_id.to_string(), ID_ENCODE_SET)
         );
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
@@ -9036,12 +8567,7 @@ impl ZoneApi for Client {
     }
 
     fn get_zones(&self) -> Result<Vec<models::Zone>, ApiError> {
-        let operation_path = format!("/v1/zones");
-        let mut url = format!(
-            "{}{}",
-            self.base_path,
-            self.remap_operation_path(operation_path)
-        );
+        let mut url = format!("{}/v1/zones", self.base_path);
 
         let mut query_string = self::url::form_urlencoded::Serializer::new("".to_owned());
 
@@ -9199,7 +8725,7 @@ fn compute_sha256(input: &[u8]) -> Result<[u8; SHA256_BYTE_LENGTH], ApiError> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{AccountsApi, AppApi, Client, Sha256Hash, SHA256_BYTE_LENGTH, SHA256_CHAR_LENGTH};
+    use crate::{Sha256Hash, SHA256_BYTE_LENGTH, SHA256_CHAR_LENGTH};
     use client::deserialize_config_checked;
     use std::convert::{From, TryFrom};
 
@@ -9251,66 +8777,5 @@ mod tests {
         let result = deserialize_config_checked(json_data, &expected_hash.0);
 
         assert!(result.is_ok())
-    }
-
-    #[test]
-    fn test_remap_operation_path() {
-        let mut client = Client::try_new_http("http://example.com:1234").unwrap();
-        assert_eq!(
-            client.remap_operation_path("/v1/test/path/no_remap".to_owned()),
-            "/v1/test/path/no_remap"
-        );
-        assert_eq!(
-            client.remap_operation_path("/v1/test/654389468329ferugfirwvbyr/no_remap".to_owned()),
-            "/v1/test/654389468329ferugfirwvbyr/no_remap"
-        );
-        client.set_use_new_paths(true);
-        assert_eq!(
-            client.remap_operation_path("/v1/something/path/remap".to_owned()),
-            "/api/v1/confidential_computing/something/path/remap"
-        );
-        assert_eq!(
-            client.remap_operation_path("/v1/test/654389468329ferugfirwvbyr/remap".to_owned()),
-            "/api/v1/confidential_computing/test/654389468329ferugfirwvbyr/remap"
-        );
-        assert_eq!(
-            client.remap_operation_path("/v1/accounts/path/no_remap".to_owned()),
-            "/v1/accounts/path/no_remap"
-        );
-        assert_eq!(
-            client.remap_operation_path("/v1/user/654389468329ferugfirwvbyr/no_remap".to_owned()),
-            "/v1/user/654389468329ferugfirwvbyr/no_remap"
-        );
-    }
-
-    #[test]
-    fn test_mock_use_new_paths() {
-        // Request a new server from the pool
-        let mut server = mockito::Server::new();
-
-        let url = server.url();
-        let mut client = Client::try_new_http(&url).unwrap();
-        // check that the old path is used before remap is enabled
-        let mock_remap_path = server
-            .mock("GET", "/v1/apps/unique_labels/count")
-            .with_status(201)
-            .create();
-        let _ = client.get_apps_unique_labels();
-        mock_remap_path.assert();
-        client.set_use_new_paths(true);
-        // check that the remap doesn't affect certain endpoints
-        let mock_no_remap_path = server.mock("GET", "/v1/accounts").with_status(200).create();
-        let _ = client.get_accounts();
-        mock_no_remap_path.assert();
-        // check that the new path is used after remap is enabled
-        let mock_remap_path = server
-            .mock(
-                "GET",
-                "/api/v1/confidential_computing/apps/unique_labels/count",
-            )
-            .with_status(201)
-            .create();
-        let _ = client.get_apps_unique_labels();
-        mock_remap_path.assert();
     }
 }


### PR DESCRIPTION
Reverts fortanix/em-client-rust#53. It should not have been merged, since it is being superseded by https://github.com/fortanix/em-client-rust/pull/54.